### PR TITLE
docs: align truth docs with templates

### DIFF
--- a/.claude/skills/truthmark-document/support/procedure.md
+++ b/.claude/skills/truthmark-document/support/procedure.md
@@ -46,7 +46,8 @@ They do not override checkout evidence, canonical truth docs, route files, or wo
 If unavailable, inspect any present Truthmark config, route files, source files, truth docs, and tests directly, then report that repository-intelligence artifacts were not generated.
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.claude/skills/truthmark-structure/support/procedure.md
+++ b/.claude/skills/truthmark-structure/support/procedure.md
@@ -17,7 +17,8 @@ Implementation code and canonical truth docs are inspected evidence for current 
 
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 - use docs/truth/**, docs/architecture/**, or docs/standards/** for current truth destinations

--- a/.claude/skills/truthmark-sync/support/procedure.md
+++ b/.claude/skills/truthmark-sync/support/procedure.md
@@ -36,7 +36,8 @@ Product Decisions/Rationale preservation gate:
 - after the edit, verify every touched truth doc still has Product Decisions and Rationale sections and every pre-existing entry is preserved, moved, narrowed, removed with evidence, or blocked
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.codex/skills/truthmark-document/support/procedure.md
+++ b/.codex/skills/truthmark-document/support/procedure.md
@@ -46,7 +46,8 @@ They do not override checkout evidence, canonical truth docs, route files, or wo
 If unavailable, inspect any present Truthmark config, route files, source files, truth docs, and tests directly, then report that repository-intelligence artifacts were not generated.
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.codex/skills/truthmark-structure/support/procedure.md
+++ b/.codex/skills/truthmark-structure/support/procedure.md
@@ -17,7 +17,8 @@ Implementation code and canonical truth docs are inspected evidence for current 
 
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 - use docs/truth/**, docs/architecture/**, or docs/standards/** for current truth destinations

--- a/.codex/skills/truthmark-sync/support/procedure.md
+++ b/.codex/skills/truthmark-sync/support/procedure.md
@@ -36,7 +36,8 @@ Product Decisions/Rationale preservation gate:
 - after the edit, verify every touched truth doc still has Product Decisions and Rationale sections and every pre-existing entry is preserved, moved, narrowed, removed with evidence, or blocked
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.gemini/commands/truthmark/document.toml
+++ b/.gemini/commands/truthmark/document.toml
@@ -52,7 +52,8 @@ They do not override checkout evidence, canonical truth docs, route files, or wo
 If unavailable, inspect any present Truthmark config, route files, source files, truth docs, and tests directly, then report that repository-intelligence artifacts were not generated.
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.gemini/commands/truthmark/structure.toml
+++ b/.gemini/commands/truthmark/structure.toml
@@ -23,7 +23,8 @@ Implementation code and canonical truth docs are inspected evidence for current 
 
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 - use docs/truth/**, docs/architecture/**, or docs/standards/** for current truth destinations

--- a/.gemini/commands/truthmark/sync.toml
+++ b/.gemini/commands/truthmark/sync.toml
@@ -42,7 +42,8 @@ Product Decisions/Rationale preservation gate:
 - after the edit, verify every touched truth doc still has Product Decisions and Rationale sections and every pre-existing entry is preserved, moved, narrowed, removed with evidence, or blocked
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.gemini/skills/truthmark-document/support/procedure.md
+++ b/.gemini/skills/truthmark-document/support/procedure.md
@@ -46,7 +46,8 @@ They do not override checkout evidence, canonical truth docs, route files, or wo
 If unavailable, inspect any present Truthmark config, route files, source files, truth docs, and tests directly, then report that repository-intelligence artifacts were not generated.
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.gemini/skills/truthmark-structure/support/procedure.md
+++ b/.gemini/skills/truthmark-structure/support/procedure.md
@@ -17,7 +17,8 @@ Implementation code and canonical truth docs are inspected evidence for current 
 
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 - use docs/truth/**, docs/architecture/**, or docs/standards/** for current truth destinations

--- a/.gemini/skills/truthmark-sync/support/procedure.md
+++ b/.gemini/skills/truthmark-sync/support/procedure.md
@@ -36,7 +36,8 @@ Product Decisions/Rationale preservation gate:
 - after the edit, verify every touched truth doc still has Product Decisions and Rationale sections and every pre-existing entry is preserved, moved, narrowed, removed with evidence, or blocked
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.github/prompts/truthmark-document.prompt.md
+++ b/.github/prompts/truthmark-document.prompt.md
@@ -65,7 +65,8 @@ They do not override checkout evidence, canonical truth docs, route files, or wo
 If unavailable, inspect any present Truthmark config, route files, source files, truth docs, and tests directly, then report that repository-intelligence artifacts were not generated.
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.github/prompts/truthmark-structure.prompt.md
+++ b/.github/prompts/truthmark-structure.prompt.md
@@ -32,7 +32,8 @@ Copilot custom-agent mode:
 
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 - use docs/truth/**, docs/architecture/**, or docs/standards/** for current truth destinations

--- a/.github/prompts/truthmark-sync.prompt.md
+++ b/.github/prompts/truthmark-sync.prompt.md
@@ -55,7 +55,8 @@ Product Decisions/Rationale preservation gate:
 - after the edit, verify every touched truth doc still has Product Decisions and Rationale sections and every pre-existing entry is preserved, moved, narrowed, removed with evidence, or blocked
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.github/skills/truthmark-document/support/procedure.md
+++ b/.github/skills/truthmark-document/support/procedure.md
@@ -46,7 +46,8 @@ They do not override checkout evidence, canonical truth docs, route files, or wo
 If unavailable, inspect any present Truthmark config, route files, source files, truth docs, and tests directly, then report that repository-intelligence artifacts were not generated.
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.github/skills/truthmark-structure/support/procedure.md
+++ b/.github/skills/truthmark-structure/support/procedure.md
@@ -17,7 +17,8 @@ Implementation code and canonical truth docs are inspected evidence for current 
 
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 - use docs/truth/**, docs/architecture/**, or docs/standards/** for current truth destinations

--- a/.github/skills/truthmark-sync/support/procedure.md
+++ b/.github/skills/truthmark-sync/support/procedure.md
@@ -36,7 +36,8 @@ Product Decisions/Rationale preservation gate:
 - after the edit, verify every touched truth doc still has Product Decisions and Rationale sections and every pre-existing entry is preserved, moved, narrowed, removed with evidence, or blocked
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.opencode/skills/truthmark-document/support/procedure.md
+++ b/.opencode/skills/truthmark-document/support/procedure.md
@@ -46,7 +46,8 @@ They do not override checkout evidence, canonical truth docs, route files, or wo
 If unavailable, inspect any present Truthmark config, route files, source files, truth docs, and tests directly, then report that repository-intelligence artifacts were not generated.
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/.opencode/skills/truthmark-structure/support/procedure.md
+++ b/.opencode/skills/truthmark-structure/support/procedure.md
@@ -17,7 +17,8 @@ Implementation code and canonical truth docs are inspected evidence for current 
 
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 - use docs/truth/**, docs/architecture/**, or docs/standards/** for current truth destinations

--- a/.opencode/skills/truthmark-sync/support/procedure.md
+++ b/.opencode/skills/truthmark-sync/support/procedure.md
@@ -36,7 +36,8 @@ Product Decisions/Rationale preservation gate:
 - after the edit, verify every touched truth doc still has Product Decisions and Rationale sections and every pre-existing entry is preserved, moved, narrowed, removed with evidence, or blocked
 When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.
 Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.
-Align existing docs to that template while preserving accurate authored content.
+Treat the HTML comments under each template section as normative authoring guidance for that section.
+Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.
 If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.
 Teams may edit the template files under docs/templates/ to define their local truth-doc standards.
 Truth-doc shape repair gate:

--- a/docs/truth/check-diagnostics.md
+++ b/docs/truth/check-diagnostics.md
@@ -18,6 +18,10 @@ source_of_truth:
 
 # Check Diagnostics
 
+## Purpose
+
+This document protects the user-facing truth-health contract for `truthmark check`: what it validates, what its diagnostics mean, and how maintainers should interpret command output.
+
 ## Scope
 
 This document describes the current behavior of `truthmark check`.
@@ -43,7 +47,7 @@ The command reports repository truth health for the active checkout. It does not
 
 Topology repair remains an installed workflow responsibility. `truthmark check` may expose routing or coverage symptoms, but AI agents must be able to perform Truth Structure directly from committed config, route files, docs, and implementation when the Truthmark binary is unavailable.
 
-## Validation Passes
+## Core Rules
 
 ### Authority
 
@@ -182,7 +186,19 @@ Current severity behavior:
 - missing evidence symbol, invalid evidence span, or stale evidence hash: `error`
 - evidence line spans are validated even when the evidence block does not include a content hash
 
-## Result Shape
+## Flows And States
+
+`truthmark check` follows this validation flow:
+
+1. Resolve the active repository and worktree.
+2. Load `.truthmark/config.yml` and configured authority roots.
+3. Build branch-scope metadata and relevant-file hashes for the current checkout.
+4. Run configured authority, area, frontmatter, link, generated-surface, coverage, decision-structure, and topology diagnostics.
+5. Render either human-readable output or the shared JSON command envelope.
+
+The command does not run Truth Sync, Truth Preview, Truth Realize, Truth Structure, or Truth Check workflows. It only reports the current repository-truth health it can derive from local checkout state.
+
+## Contracts
 
 - human output reports the number of `error` and `review` diagnostics
 - JSON output returns the shared command envelope
@@ -197,8 +213,6 @@ Branch scope identifies the active checkout:
 - detached checkouts use the commit SHA
 - worktree path is reported separately for parallel worktrees
 - relevant file hashes track `.truthmark/config.yml`, the configured root route index, and configured child route files
-
-## Practical Meaning
 
 - `error` means the current routing or contract is invalid and should be fixed before relying on the docs tree.
 - `review` means the tree is usable, but maintainers should decide whether the reported gap is intentional.
@@ -220,7 +234,16 @@ Keeping check non-orchestrating means repositories can use it in local audits or
 
 Keeping topology repair in generated agent workflows preserves portability: a repository with committed Truthmark surfaces remains usable in AI environments that cannot run the Truthmark CLI.
 
-## Primary Code Files
+## Non-Goals
+
+- `truthmark check` is not a workflow orchestrator.
+- `truthmark check` is not the runtime for installed agent skills, prompts, or commands.
+- `truthmark check` does not rewrite truth docs, route files, generated surfaces, or functional code.
+- Passing `truthmark check` does not prove every truth doc already matches the latest template taxonomy.
+
+## Maintenance Notes
+
+Primary implementation files:
 
 - `src/checks/check.ts`
 - `src/checks/authority.ts`
@@ -228,3 +251,5 @@ Keeping topology repair in generated agent workflows preserves portability: a re
 - `src/checks/frontmatter.ts`
 - `src/checks/links.ts`
 - `src/checks/branch-scope.ts`
+
+Update this doc when check diagnostics, JSON data shape, branch-scope behavior, generated-surface diagnostics, topology diagnostics, or severity rules change.

--- a/docs/truth/check-diagnostics.md
+++ b/docs/truth/check-diagnostics.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: behavior
-last_reviewed: 2026-05-14
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../src/checks/check.ts
   - ../../src/checks/authority.ts
@@ -24,7 +24,7 @@ This document protects the user-facing truth-health contract for `truthmark chec
 
 ## Scope
 
-This document describes the current behavior of `truthmark check`.
+This document owns the current behavior of `truthmark check`: config-aware validation of authority files, route areas, frontmatter, links, decision structure, generated surfaces, coverage, and optional branch-impact freshness diagnostics. Installed agent workflow behavior is covered by the workflow truth docs instead of this CLI diagnostics surface.
 
 ## Current Behavior
 

--- a/docs/truth/contracts.md
+++ b/docs/truth/contracts.md
@@ -18,6 +18,10 @@ source_of_truth:
 
 # Contracts
 
+## Purpose
+
+This document protects Truthmark machine-facing contracts: configuration, route metadata, CLI JSON envelopes, command result data, diagnostics, compatibility, and migration behavior.
+
 ## Scope
 
 This document defines the current machine-facing contracts exposed by Truthmark: the config file shape, route metadata, repository-intelligence artifacts, and the CLI result envelope.
@@ -33,8 +37,6 @@ This document defines the current machine-facing contracts exposed by Truthmark:
 - Committed config fields under `.truthmark/config.yml`.
 - Routed truth-document metadata from `docs/truthmark/areas.md` and `docs/truthmark/areas/**/*.md`.
 - CLI options such as `--json`, `--stdout`, and command-specific flags.
-
-## Config Contract
 
 Truthmark loads `.truthmark/config.yml` and validates it against the current schema.
 
@@ -62,8 +64,6 @@ The default scaffolded authority list includes:
 - `docs/standards/**/*.md`
 - `docs/architecture/**/*.md`
 - `docs/truth/**/*.md`
-
-## Route Metadata Contract
 
 Route files may express `Truth documents` in either of these forms:
 
@@ -97,7 +97,7 @@ Supported `platforms` values are:
 
 There is no `.truthmark/local.yml` contract in the current implementation. User preferences that affect generated repository behavior must be expressed through committed config or the generated surfaces cannot be reproduced by another checkout.
 
-## Command Result Envelope
+## Outputs
 
 `truthmark config`, `truthmark init`, `truthmark check`, and `truthmark validate ...` commands return the same JSON envelope when run with `--json`.
 
@@ -144,18 +144,6 @@ The command summary is `Validation passed` when `ok` is true and `Validation fai
 
 RepoIndex, RouteMap, ImpactSet, and ContextPack are derived from the active checkout. They do not override route files, source files, truth docs, or installed workflow write boundaries.
 
-## Compatibility Rules
-
-- `version` remains `1` in the committed config contract.
-- `docs.roots.truth` is the configured root for behavior truth docs.
-- Repositories refresh generated workflow surfaces through `truthmark init`; removing a platform from config stops future refreshes but does not delete previously generated files.
-- Truth Realize has no config switch; selected platforms receive its explicit manual workflow surface.
-- `truthmark-portal` is an optional namespaced config block. When omitted, normalized `truthmarkPortal` is `{ enabled: false, output: "docs/truthmark-portal", template: "default" }`; an existing block with omitted `enabled` also remains disabled.
-- `truthmark-portal.output` and `truthmark-portal.template` must be strings when present. Output must be a non-empty repository-relative directory without absolute or parent traversal segments and must not overlap source roots, instruction targets, `.truthmark/config.yml`, route files, or canonical Markdown roots. Template must be `default` or a non-empty repository-relative path without absolute or parent traversal segments.
-- There is no `.truthmark/local.yml` compatibility surface in the current implementation.
-
-## Config Result Data
-
 `truthmark config --json` writes only `.truthmark/config.yml` unless `--stdout` is used.
 
 Current config result data fields include:
@@ -170,8 +158,6 @@ When `--stdout` is used, `data` also includes:
 
 - `path`
 - `content`
-
-## Init Result Data
 
 `truthmark init --json` currently returns these data fields:
 
@@ -300,8 +286,6 @@ Generated `SKILL.md` files use closed YAML frontmatter with `name`, `description
 
 The OpenCode `truth-doc-writer` edit allow-list is rendered from the active `docs.roots.truth`, `docs.routing.root_index`, and `docs.routing.area_files_root` config paths so valid leases remain writable in non-default documentation layouts.
 
-## Check Result Data
-
 `truthmark check --json` returns:
 
 - `branchScope`
@@ -333,7 +317,7 @@ For normal branches, `identity` is branch name plus HEAD SHA. For detached check
 - `syncCompletenessIssueCount`
 - `topologyPressureCount`
 
-## Current Diagnostic Emission Notes
+## Errors And Diagnostics
 
 - ordinary `truthmark check` emits `config`, `authority`, `frontmatter`, `links`, `area-index`, `coverage`, `doc-structure`, and `generated-surface` diagnostics.
 - `truth-sync` and `realization` categories exist for init and generated workflow reporting, but ordinary `check` does not emit workflow payloads.
@@ -343,6 +327,24 @@ For normal branches, `identity` is branch name plus HEAD SHA. For detached check
 - Coverage diagnostics discover unmapped functional code across common code roots with the same path classifier used by Truth Sync. V1 coverage must include Go, Python, C#, Java, JavaScript, TypeScript, frontend roots, monorepo app or package roots, Terraform, Kubernetes manifests, CI workflows, OpenAPI or Swagger, GraphQL, and protobuf surfaces within those roots.
 - `frontmatter` emits `error` diagnostics when `truth_kind` is invalid or present and disagrees with routed truth-kind metadata.
 - `doc-structure` emits `review` diagnostics when configured architecture or routed truth docs are missing `Scope`, active `Product Decisions`, active `Rationale`, or the kind-specific required headings for their routed truth kind.
+
+## Compatibility Rules
+
+- `version` remains `1` in the committed config contract.
+- `docs.roots.truth` is the configured root for behavior truth docs.
+- Repositories refresh generated workflow surfaces through `truthmark init`; removing a platform from config stops future refreshes but does not delete previously generated files.
+- Truth Realize has no config switch; selected platforms receive its explicit manual workflow surface.
+- `truthmark-portal` is an optional namespaced config block. When omitted, normalized `truthmarkPortal` is `{ enabled: false, output: "docs/truthmark-portal", template: "default" }`; an existing block with omitted `enabled` also remains disabled.
+- `truthmark-portal.output` and `truthmark-portal.template` must be strings when present. Output must be a non-empty repository-relative directory without absolute or parent traversal segments and must not overlap source roots, instruction targets, `.truthmark/config.yml`, route files, or canonical Markdown roots. Template must be `default` or a non-empty repository-relative path without absolute or parent traversal segments.
+- There is no `.truthmark/local.yml` compatibility surface in the current implementation.
+
+## Versioning And Migration
+
+- The committed config contract remains `version: 1` until an intentional schema-version migration is implemented.
+- Route metadata accepts both legacy Markdown truth-document lists and fenced YAML `truth_documents` arrays for compatibility with existing repositories.
+- Repositories refresh generated workflow surfaces and templates through `truthmark init`; removing a platform from config stops future refreshes but does not delete previously generated files.
+- New command data fields should be additive where possible and remain nested under the shared command envelope.
+- Helper validators must keep helper-specific data under `data.validation` rather than returning raw validator payloads at the top level.
 
 ## Product Decisions
 
@@ -358,3 +360,13 @@ For normal branches, `identity` is branch name plus HEAD SHA. For detached check
 Separating config from init keeps repository layout reviewable and predictable. Keeping decisions with the owning behavior, contract, or architecture doc prevents agents from having to infer which historical note is still active.
 
 Keeping workflow verbs out of the CLI preserves the agent-native model: installed skills and instruction blocks run the workflows, while the CLI installs and validates repository artifacts.
+
+## Non-Goals
+
+- This doc does not define human prose style for truth docs; templates and standards own that.
+- This doc does not make installed agent workflows CLI subcommands.
+- This doc does not define every generated host file path except where those paths are part of command, validator, or generated-surface contracts.
+
+## Maintenance Notes
+
+Update this doc when `.truthmark/config.yml` schema, route metadata forms, command names/options, JSON envelopes, command-specific `data` payloads, diagnostic categories/severities, helper validator envelopes, or compatibility guarantees change.

--- a/docs/truth/init-and-scaffold.md
+++ b/docs/truth/init-and-scaffold.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: behavior
-last_reviewed: 2026-05-18
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../src/config/defaults.ts
   - ../../src/fs/paths.ts
@@ -26,7 +26,7 @@ This document protects the repository setup contract for `truthmark config` and 
 
 ## Scope
 
-This document describes the current behavior of `truthmark config` and `truthmark init`.
+This document owns the current setup and scaffold behavior for `truthmark config` and `truthmark init`: config-file creation, default docs and routes, editable typed templates, managed instruction blocks, generated platform surfaces, and migration-risk reporting. It hands ongoing truth-doc content maintenance to the routed truth docs and workflow surfaces.
 
 ## Current Behavior
 

--- a/docs/truth/init-and-scaffold.md
+++ b/docs/truth/init-and-scaffold.md
@@ -20,6 +20,10 @@ source_of_truth:
 
 # Init And Scaffold
 
+## Purpose
+
+This document protects the repository setup contract for `truthmark config` and `truthmark init`: how configuration is created, what init scaffolds or refreshes, and which generated surfaces are managed.
+
 ## Scope
 
 This document describes the current behavior of `truthmark config` and `truthmark init`.
@@ -41,7 +45,7 @@ This document describes the current behavior of `truthmark config` and `truthmar
 9. reports migration risks instead of moving existing truth docs when hierarchy changes imply manual migration
 10. reports each touched file as `created`, `updated`, or `unchanged`
 
-## Scaffolded Files
+## Core Rules
 
 Current scaffold targets:
 
@@ -166,8 +170,6 @@ The generated Truth Structure, Truth Document, Truth Sync, Truth Preview, Truth 
 
 Truthmark Portal surfaces are managed by the same renderer only when normalized `truthmarkPortal.enabled` is `true`. When disabled or omitted, init emits no Portal skills, prompts, commands, or managed-instruction mention.
 
-## AGENTS Management Rules
-
 The current managed-instruction update behavior is:
 
 - replace an existing managed Truthmark block when it is well formed
@@ -184,8 +186,6 @@ Repository-specific instructions should therefore live outside the managed block
 
 Truthmark does not create `OPENCODE.md` in V1. OpenCode-compatible behavior is installed through shared `AGENTS.md` guidance and project skill files under `.opencode/skills/`.
 
-## Hierarchy Behavior
-
 Hierarchy is configured in `.truthmark/config.yml`:
 
 - `docs.layout` is currently `hierarchical`
@@ -199,8 +199,6 @@ Hierarchy is configured in `.truthmark/config.yml`:
 The default scaffold treats truth `README.md` files as indexes. Current behavior truth belongs in bounded leaf docs under the configured truth root, such as `<truth-root>/<domain>/<behavior>.md`.
 `truthmark init` creates [docs/templates/behavior-doc.md](../templates/behavior-doc.md) when it is missing or empty and refreshes all six templates under `docs/templates/*.md` on rerun. Template refreshes replace Truthmark-owned default sections with the current professional guidance baseline, including evidence, boundary, current-state, contract, operational, verification, decision, rationale, non-goal, and maintenance prompts. Existing template preambles/frontmatter are preserved so repository-owned metadata, custom titles, source-of-truth defaults, and local introductory guidance do not churn during section refresh. Project-specific custom `##` sections are preserved and reinserted before the next default section that followed them in the authored file; trailing custom sections remain trailing. Fenced code blocks are ignored while finding `##` template sections, so examples can contain Markdown headings without being split or mistaken for Truthmark-owned sections. The default child route references the seeded leaf truth doc with fenced YAML `truth_documents` metadata and `kind: behavior` rather than relying on path inference.
 When creating the default bounded behavior truth doc, init reads the repository's merged behavior template and expands supported placeholders such as `{{title}}`, `{{area}}`, `{{source_of_truth}}`, `{{purpose}}`, `{{scope}}`, `{{current_behavior}}`, `{{core_rules}}`, `{{flows_and_states}}`, `{{contracts}}`, `{{decision}}`, `{{rationale}}`, `{{non_goals}}`, `{{maintenance_notes}}`, and `{{template_path}}`. The seeded leaf uses `doc_type: behavior` and `truth_kind: behavior`. Existing non-empty truth docs are preserved; existing template files are merged rather than blindly overwritten so teams can keep local truth-doc standard sections while receiving updated default guidance.
-
-## Current Defaults
 
 Important current defaults:
 
@@ -222,7 +220,23 @@ Important current defaults:
 - Gemini CLI support uses `GEMINI.md` for hierarchical memory, `.gemini/commands/truthmark/*.toml` for explicit workflow commands with `{{args}}` focus forwarding, `.gemini/skills/truthmark-*/` for Agent Skills, and `.gemini/agents/*.md` for project subagents instead of introducing Truthmark-specific top-level CLI verbs or Gemini extensions
 - helper files are emitted only for workflows with declared helpers and configured skill-package platforms (`codex`, `opencode`, `claude-code`, `github-copilot`, and `gemini-cli`); helper manifests call installed Truthmark CLI validators and generated packages do not bundle repo-local `scripts/*.mjs` helper copies
 
-## Init Diagnostics
+- all generated paths must remain inside the active repository root
+- generated path containment must reject symlinks that resolve outside the repository, including broken symlink leaves that would otherwise be created outside the worktree
+- init must be idempotent for existing non-empty scaffold files except for managed update surfaces such as instruction blocks, generated workflow assets, and merged `docs/templates/*.md` default sections
+- the command should remain safe to run repeatedly in the same repository
+
+## Flows And States
+
+The setup flow is:
+
+1. `truthmark config` writes or prints the repository configuration.
+2. `truthmark init` requires an existing valid config and resolves the active Git worktree.
+3. Init creates missing configured routing, truth-root, default-area, standards, template, and generated workflow surfaces.
+4. Init refreshes managed surfaces that Truthmark owns, including managed instruction blocks, generated host workflow assets, and default sections in `docs/templates/*.md`.
+5. Init preserves repository-authored content outside managed blocks and preserves template preambles/frontmatter plus custom template sections when refreshing default template sections.
+6. Init reports every created, updated, or unchanged surface as an action diagnostic in the shared command envelope.
+
+## Contracts
 
 Current init JSON reporting uses:
 
@@ -231,12 +245,7 @@ Current init JSON reporting uses:
 - `authority` for [docs/truthmark/areas.md](../truthmark/areas.md)
 - `config` for the remaining scaffolded files
 
-## Invariants
-
-- all generated paths must remain inside the active repository root
-- generated path containment must reject symlinks that resolve outside the repository, including broken symlink leaves that would otherwise be created outside the worktree
-- init must be idempotent for existing non-empty scaffold files except for managed update surfaces such as instruction blocks, generated workflow assets, and merged `docs/templates/*.md` default sections
-- the command should remain safe to run repeatedly in the same repository
+`truthmark config --json` and `truthmark init --json` use the shared command-result envelope described in [contracts.md](contracts.md). `truthmark init` requires a valid config and does not silently migrate existing truth-doc placement.
 
 ## Product Decisions
 
@@ -260,10 +269,22 @@ Keeping host-specific detail in generated skills and Gemini command files preven
 
 Keeping typed truth-doc templates in `docs/templates/` gives repository owners one local standard surface per truth kind while keeping generated workflow text compact as more workflow surfaces are added. Refreshing default template sections on `truthmark init` keeps those local standard surfaces aligned with current professional guidance, while preserving custom sections prevents product-specific review gates from being erased by package upgrades.
 
-## Primary Code Files
+## Non-Goals
+
+- Init does not create `.truthmark/config.yml`; `truthmark config` owns that step.
+- Init does not silently migrate existing truth docs to a new hierarchy.
+- Init does not overwrite manual text outside managed instruction blocks.
+- Init does not replace repository-authored template preambles/frontmatter or custom template sections during template refresh.
+- Init does not delete generated files for platforms that were later removed from config.
+
+## Maintenance Notes
+
+Primary implementation files:
 
 - `src/init/init.ts`
 - `src/templates/init-files.ts`
 - `src/templates/agents-block.ts`
 - `src/templates/workflow-surfaces.ts`
 - `src/fs/paths.ts`
+
+Update this doc when scaffold targets, managed-surface categories, template refresh behavior, generated platform surfaces, config defaults, or init diagnostics change.

--- a/docs/truth/release/automation.md
+++ b/docs/truth/release/automation.md
@@ -44,6 +44,12 @@ The repository also ships `examples/github-actions/truthmark-impact.yml` as a co
 - The `Publish` workflow runs when a GitHub release is published.
 - The `publish` job checks out the repository, installs Node 24 with the npm registry configured, runs `npm ci`, runs `npm run release:check`, and then runs `npm publish`.
 
+Core automation rules:
+
+- Pull request and main-branch automation must verify linting, types, tests, build output, and package-file integrity through the existing npm scripts.
+- Publish automation must re-run the full release verification before publishing.
+- Publishing is triggered from a GitHub release event, not from branch pushes alone.
+
 ## State, Retry, And Failure Behavior
 
 - Failed verification or release-check steps stop the current job and prevent later publish steps from running.
@@ -55,18 +61,6 @@ The repository also ships `examples/github-actions/truthmark-impact.yml` as a co
 
 - CI verification results for pushes and pull requests
 - npm publication after a successful release-triggered publish job
-
-## Core Rules
-
-- Pull request and main-branch automation must verify linting, types, tests, build output, and package-file integrity through the existing npm scripts.
-- Publish automation must re-run the full release verification before publishing.
-- Publishing is triggered from a GitHub release event, not from branch pushes alone.
-
-## Contracts
-
-- Both workflows currently run on `ubuntu-latest`.
-- Both workflows install Node 24 through `actions/setup-node@v4`.
-- The publish workflow requires npm registry access through the configured GitHub Actions environment.
 
 ## Product Decisions
 
@@ -85,3 +79,10 @@ Keeping workflow steps thin makes repository automation follow the same verifica
 
 - Update this doc when workflow triggers, Node versions, or verification commands change.
 - Keep this doc aligned with `package.json` scripts used by the workflows.
+
+Workflow contracts:
+
+- Both workflows currently run on `ubuntu-latest`.
+- Both workflows install Node 24 through `actions/setup-node@v6`.
+- The CI workflow constrains `GITHUB_TOKEN` to `contents: read`.
+- The publish workflow requires `contents: read`, `id-token: write`, and npm registry access through the configured GitHub Actions environment.

--- a/docs/truth/release/automation.md
+++ b/docs/truth/release/automation.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-14
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../truthmark/areas/release-automation.md
   - ../../../.github/workflows/ci.yml
@@ -21,9 +21,9 @@ This doc covers the committed GitHub Actions workflows under `.github/workflows/
 
 ## Triggers
 
-- Pushes to `main`
-- Pull requests
-- Published GitHub releases
+- Pushes to the `main` branch start the `CI` workflow.
+- Pull request events start the same `CI` verification workflow before merge.
+- Published GitHub release events start the `Publish` workflow; branch pushes and pull requests do not publish.
 
 ## Inputs
 

--- a/docs/truth/repository/context-pack.md
+++ b/docs/truth/repository/context-pack.md
@@ -11,6 +11,10 @@ source_of_truth:
 
 # ContextPack
 
+## Purpose
+
+This document protects ContextPack v0 as a bounded, derived workflow-context artifact for Truth Sync, Truth Document, and Truth Realize.
+
 ## Scope
 
 This document owns ContextPack v0 behavior for Truth Sync, Truth Document, and Truth Realize workflows.
@@ -31,9 +35,13 @@ ContextPack output includes `schemaVersion: context-pack/v0`. It is generated fr
 - ContextPack-only text is not evidence. Generated docs must cite checkout files, route files, truth docs, tests, schemas, or explicit evidence blocks.
 - If ContextPack conflicts with the current checkout, the checkout wins.
 
-## Runtime Dependency Boundary
+## Flows And States
 
-ContextPack requires the Truthmark CLI or an equivalent local runner. If unavailable, agents must follow the installed workflow manually by reading route files, truth docs, source files, and tests directly. Completion reports must say ContextPack was not generated.
+`truthmark context` resolves route ownership, affected truth docs, selected source files, related tests, and write-boundary guidance from the active checkout, then renders JSON or deterministic Markdown for the selected workflow. Agents use the artifact as reviewable context and still inspect the checkout directly before acting.
+
+## Contracts
+
+`truthmark context --workflow <workflow> [--base <ref>] --json` returns the shared command envelope with ContextPack data. `--format markdown` renders deterministic Markdown, and `--json --format markdown` includes rendered Markdown in `data.markdown`. Unsupported formats produce a `context-pack` error diagnostic.
 
 ## Product Decisions
 
@@ -44,8 +52,20 @@ ContextPack requires the Truthmark CLI or an equivalent local runner. If unavail
 
 ContextPack makes agent context auditable without making hidden retrieval or stale generated artifacts authoritative. Keeping it derived prevents a fast path from changing ownership or write behavior.
 
-## Primary Code Files
+## Non-Goals
+
+- ContextPack is not repository authority.
+- ContextPack does not grant permissions beyond installed workflow boundaries.
+- ContextPack does not replace direct checkout inspection.
+
+## Maintenance Notes
+
+ContextPack requires the Truthmark CLI or an equivalent local runner. If unavailable, agents must follow the installed workflow manually by reading route files, truth docs, source files, and tests directly. Completion reports must say ContextPack was not generated.
+
+Primary implementation files:
 
 - `src/context-pack/build.ts`
 - `src/context-pack/render.ts`
 - `src/impact/build.ts`
+
+Update this doc when the command output, schema version, derived inputs, fallback behavior, or workflow relationship changes.

--- a/docs/truth/repository/impact-set.md
+++ b/docs/truth/repository/impact-set.md
@@ -11,6 +11,10 @@ source_of_truth:
 
 # ImpactSet
 
+## Purpose
+
+This document protects ImpactSet v0 as the derived mapping from Git changes to routed truth ownership, affected docs, affected tests, and public-symbol impact.
+
 ## Scope
 
 This document owns ImpactSet v0 behavior. ImpactSet maps Git changes to Truthmark routes, truth docs, owning areas, related tests, and public symbol changes.
@@ -33,11 +37,13 @@ ImpactSet reports changed files, affected routes, affected truth docs, affected 
 - Changed public symbols produce review diagnostics when no affected truth doc exists or when affected truth docs exist but were not changed in the impact set.
 - ImpactSet is derived. It does not grant write permission and does not replace route ownership.
 
-## Runtime Dependency Boundary
+## Flows And States
 
-ImpactSet requires the Truthmark CLI or an equivalent local runner. If unavailable, agents must inspect Git changes and route ownership directly. The workflow may proceed manually, but completion reports must say ImpactSet was not generated.
+`truthmark impact --base <ref> --json` compares the active checkout to the supplied base ref, combines Git diff data with RepoIndex and RouteMap data, and reports changed files, affected routes, affected truth docs, affected tests, changed public symbols, and diagnostics. It includes staged, unstaged, and untracked worktree changes so local agent work can be evaluated before commit.
 
-If an ImpactSet conflicts with the current checkout, agents must trust the checkout and rerun or ignore the artifact.
+## Contracts
+
+`truthmark impact --base <ref> --json` returns the shared command envelope with `schemaVersion: impact-set/v0` data. Renames preserve `previousPath`, and changed test files are reported as affected tests rather than missing truth-route diagnostics.
 
 ## Product Decisions
 
@@ -48,8 +54,22 @@ If an ImpactSet conflicts with the current checkout, agents must trust the check
 
 ImpactSet gives Truth Sync and CI a stable, reviewable way to explain what code changed and which truth surfaces are affected without making a model decide ownership.
 
-## Primary Code Files
+## Non-Goals
+
+- ImpactSet is not a background cache.
+- ImpactSet does not replace route files as ownership authority.
+- ImpactSet does not override the current checkout when an artifact conflicts with local files.
+
+## Maintenance Notes
+
+ImpactSet requires the Truthmark CLI or an equivalent local runner. If unavailable, agents must inspect Git changes and route ownership directly. The workflow may proceed manually, but completion reports must say ImpactSet was not generated.
+
+If an ImpactSet conflicts with the current checkout, agents must trust the checkout and rerun or ignore the artifact.
+
+Primary implementation files:
 
 - `src/impact/build.ts`
 - `src/impact/git-diff.ts`
 - `src/repo-index/build.ts`
+
+Update this doc when the command output, schema version, derived inputs, fallback behavior, or workflow relationship changes.

--- a/docs/truth/repository/repo-index.md
+++ b/docs/truth/repository/repo-index.md
@@ -12,6 +12,10 @@ source_of_truth:
 
 # RepoIndex
 
+## Purpose
+
+This document protects RepoIndex v0 and RouteMap v0 as deterministic, local repository-intelligence artifacts derived from the active checkout.
+
 ## Scope
 
 This document owns RepoIndex v0 and RouteMap v0 behavior. RepoIndex describes the current checkout's files, docs, packages, tests, JavaScript/TypeScript imports and exports, public symbols, and Truthmark route ownership.
@@ -32,11 +36,13 @@ RepoIndex output includes `schemaVersion: repo-index/v0`. RouteMap output includ
 - Route ownership comes from Truthmark area files, not from package structure or import graphs.
 - RepoIndex and RouteMap are derived artifacts. They speed up routing and review, but they do not override source files, route files, or truth docs.
 
-## Runtime Dependency Boundary
+## Flows And States
 
-RepoIndex requires the Truthmark CLI or an equivalent local runner to compute. If the CLI is unavailable, agents must inspect `.truthmark/config.yml`, route files, changed source files, and routed truth docs directly. Workflows may proceed manually, but completion reports must say RepoIndex and RouteMap were not generated.
+`truthmark index --json` reads local files, Git metadata, config, route files, Markdown docs, package metadata, tests, JavaScript/TypeScript imports and exports, public symbols, and route ownership. It does not start a daemon, call a model, call a remote service, or write generated artifacts by default.
 
-If a RepoIndex or RouteMap artifact conflicts with the current checkout, the checkout wins. Agents must rerun the CLI when available or ignore the stale artifact when it cannot be regenerated.
+## Contracts
+
+`truthmark index --json` returns the shared command envelope with `schemaVersion: repo-index/v0` data. RouteMap output uses `schemaVersion: route-map/v0`. Paths are repository-relative POSIX paths, arrays are sorted lexicographically unless source order is contractual, and file discovery honors Git ignore rules plus Truthmark config ignores.
 
 ## Product Decisions
 
@@ -47,9 +53,23 @@ If a RepoIndex or RouteMap artifact conflicts with the current checkout, the che
 
 Keeping repository intelligence derived preserves Truthmark's branch-local review boundary. Teams can use fast machine-readable context when the CLI is available without making installed workflows unusable in constrained agent environments.
 
-## Primary Code Files
+## Non-Goals
+
+- RepoIndex is not a source of truth.
+- RepoIndex does not grant workflow write permissions.
+- RepoIndex does not replace direct inspection when the CLI is unavailable or stale.
+
+## Maintenance Notes
+
+RepoIndex requires the Truthmark CLI or an equivalent local runner to compute. If the CLI is unavailable, agents must inspect `.truthmark/config.yml`, route files, changed source files, and routed truth docs directly. Workflows may proceed manually, but completion reports must say RepoIndex and RouteMap were not generated.
+
+If a RepoIndex or RouteMap artifact conflicts with the current checkout, the checkout wins. Agents must rerun the CLI when available or ignore the stale artifact when it cannot be regenerated.
+
+Primary implementation files:
 
 - `src/repo-index/build.ts`
 - `src/repo-index/file-tree.ts`
 - `src/repo-index/route-map.ts`
 - `src/repo-index/types.ts`
+
+Update this doc when the command output, schema version, derived inputs, fallback behavior, or workflow relationship changes.

--- a/docs/truth/routing-examples.md
+++ b/docs/truth/routing-examples.md
@@ -13,6 +13,10 @@ source_of_truth:
 
 This document gives examples for designing explicit Truthmark areas in larger repositories. The examples are patterns, not required folder names.
 
+## Purpose
+
+This document protects reusable routing examples that help maintainers split larger repositories by durable behavior ownership rather than broad directory mirroring.
+
 ## Scope
 
 This doc covers example routing patterns for larger repositories so agents and maintainers can split route ownership by behavior rather than by broad directory mirroring.
@@ -22,29 +26,42 @@ This doc covers example routing patterns for larger repositories so agents and m
 - Truthmark treats frontend, API schema, workflow, infrastructure, and monorepo service paths as functional surfaces when they change production behavior, contracts, or operational ownership.
 - Route design should produce bounded truth owners that map changed code to a small set of canonical docs.
 
-## Express, Nest, And Fastify
+## Core Rules
+
+- Route production behavior, contracts, and operational ownership explicitly.
+- Prefer bounded product, service, workflow, or platform ownership over one broad catch-all route.
+- Treat frontend, API schema, workflow, infrastructure, and monorepo service paths as functional surfaces when they change behavior, contracts, deployment, permissions, or availability.
+- Use delegated child route files when one root route would otherwise own unrelated services, packages, or user flows.
+
+## Flows And States
+
+### Express, Nest, And Fastify
 
 Large Node API apps should route by product behavior rather than by framework layer. For example, route `src/modules/billing/**`, `src/routes/billing/**`, or `apps/api/src/billing/**` to a billing truth doc instead of routing all controllers through `src/**`.
 
 API schema files are functional surfaces when they define behavior or contracts. Route `api/openapi.yaml`, `schema/**/*.graphql`, and `proto/**/*.proto` to the nearest contract or behavior truth doc.
 
-## Frontend Apps
+### Frontend Apps
 
 Frontend repositories should route user-facing flows, app shells, and shared UI behavior explicitly. Useful code surfaces include `frontend/**`, `web/**`, `client/**`, `apps/*/src/**`, and product-owned component folders such as `components/checkout/**`.
 
 Avoid a single catch-all frontend area once multiple flows have independent product decisions or release risks.
 
-## Terraform And Kubernetes
+### Terraform And Kubernetes
 
 Infrastructure-as-code is functional when it changes runtime behavior, deployment topology, permissions, or availability. Route `infra/**`, `terraform/**`, `k8s/**`, and `kubernetes/**` to operational or platform truth docs.
 
 Kubernetes and Terraform changes should not disappear under generic config handling when they affect the deployed system.
 
-## Service Monorepos
+### Service Monorepos
 
 Service monorepos should prefer bounded service or package ownership: `services/payments/**`, `apps/admin/**`, `packages/auth/**`, and similar paths should map to specific behavior or platform docs.
 
 Use delegated child route files when one root route would otherwise own unrelated services or packages.
+
+## Contracts
+
+Routing examples must remain examples of valid `Code surface`, `Truth documents`, and `Update truth when` thinking. They do not change the route-file schema; concrete repositories still express ownership through their configured route files.
 
 ## Product Decisions
 
@@ -53,3 +70,13 @@ Decision (2026-05-09): Truthmark treats frontend, API schema, workflow, IaC, and
 ## Rationale
 
 Agents need routeable evidence for the code surfaces that change production behavior. Keeping these examples canonical reduces broad catch-all routing and makes unmapped surfaces easier to review.
+
+## Non-Goals
+
+- This doc does not define a complete route map for every possible framework.
+- This doc does not require teams to mirror directory layout mechanically.
+- This doc does not replace repository-specific routing decisions in `docs/truthmark/areas.md` and child area files.
+
+## Maintenance Notes
+
+Update this doc when Truthmark routing guidance changes for frontend apps, API schemas, infrastructure-as-code, workflow code, or service monorepos.

--- a/docs/truth/workflows/content-generation.md
+++ b/docs/truth/workflows/content-generation.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-15
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/generation/**
 ---
@@ -15,11 +15,13 @@ Content-generation prompt contracts shape draft truth-doc updates without becomi
 
 ## Scope
 
-This document owns source-internal draft prompt contracts used by Truthmark workflow code.
+This document owns the source-internal prompt, schema, registry, and validation contracts under `src/generation/**` that draft truth-doc updates from bounded evidence context. Installed workflow surfaces own permissions, write boundaries, and final acceptance.
 
 ## Triggers
 
-- renderer or schema changes under `src/generation/**`
+- prompt renderer, schema, registry, type, or validator changes under `src/generation/**`
+- changes to draft-output semantics such as evidence IDs, relevant-doc path checks, blocked status rules, patch-path validation, or JSON parsing requirements
+- workflow changes that alter how generated draft content is consumed or rejected
 
 ## Inputs
 
@@ -62,8 +64,9 @@ Separating draft generation from workflow authority prevents helper prompts from
 
 ## Non-Goals
 
-- no permission grants from draft prompts
-- no replacement for direct checkout inspection
+- no permission grants, write leases, or workflow authority from draft prompts
+- no replacement for direct checkout inspection, route ownership review, or final workflow acceptance
+- no unrestricted patch paths outside repository-relative `docs/**` targets supplied by the bounded context
 
 ## Maintenance Notes
 

--- a/docs/truth/workflows/content-generation.md
+++ b/docs/truth/workflows/content-generation.md
@@ -33,9 +33,24 @@ Workflow prompts grant permissions and set write boundaries. Content-generation 
 
 Generated draft content remains advisory until a workflow-authorized agent applies it to canonical docs.
 
-## Current Behavior
+## Steps
+
+1. Source workflow code gathers evidence context and target-doc boundaries.
+2. Content-generation prompt contracts render that context for draft generation.
+3. Structured output schemas validate draft shape where applicable.
+4. A workflow-authorized agent decides whether and how to apply the draft to canonical docs under the installed workflow write boundary.
+
+Current behavior notes:
 
 Truthmark keeps content-generation contracts separate from installed workflow authority. Agents still inspect the checkout directly and use installed workflow surfaces for permissions, boundaries, and reporting.
+
+## State, Retry, And Failure Behavior
+
+Draft prompt output is advisory state only. If generation fails, schema validation fails, or evidence is insufficient, the owning workflow must fall back to direct checkout inspection and either write a supported truth-doc update or report why it blocked.
+
+## Outputs
+
+Generated draft content may become proposed truth-doc prose only after a workflow-authorized agent validates it against checkout evidence and applies it within allowed write paths. The prompt contracts themselves do not produce authoritative repository truth.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/overview.md
+++ b/docs/truth/workflows/overview.md
@@ -44,7 +44,14 @@ Installed skills, prompts, commands, and managed instruction blocks are the work
 
 Agents inspect the checkout directly, apply workflow boundaries from committed surfaces, update only workflow-allowed files, and report what changed.
 
-## Current Behavior
+## Steps
+
+1. `truthmark init` reads `.truthmark/config.yml` and refreshes managed instruction blocks plus configured host surfaces.
+2. Generated host surfaces expose explicit manual workflows and the automatic finish-time Truth Sync guidance.
+3. An agent invokes or follows a generated surface, reads the checkout directly, applies workflow write boundaries, and reports the outcome.
+4. Optional CLI helpers may validate reports, build context, or index the repository, but they do not orchestrate workflow execution.
+
+Current behavior notes:
 
 The default platform list includes every supported platform. Teams should remove unused platforms from `.truthmark/config.yml` before rerunning `truthmark init`.
 
@@ -72,6 +79,14 @@ Truthmark Portal surfaces are generated only when `truthmark-portal.enabled` nor
 Truthmark-owned workflow surfaces are generated under host-specific directories. Repo-root `skills/` files are not generated V1 workflow surfaces.
 
 Managed instruction blocks are compact automatic-Sync trigger and boundary indexes. They intentionally omit platform-specific invocation strings, non-automatic workflow procedures, report examples, and long checklists. Detailed invocations and procedures live in generated skills, skill support files, prompts, and command files.
+
+## State, Retry, And Failure Behavior
+
+Generated workflow surfaces are committed repository files. If the Truthmark package is unavailable at workflow-execution time, agents still follow the committed surfaces manually and report unavailable optional helper output. Removing a platform from config stops future refreshes for that platform but does not delete already committed surfaces.
+
+## Outputs
+
+The installed runtime outputs managed instruction blocks, host-native skills/prompts/commands/agents, optional helper validation reports, and agent completion reports. Canonical truth remains in Markdown docs and route files.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/shared-gates.md
+++ b/docs/truth/workflows/shared-gates.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-15
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/shared.ts
   - ../../../src/truth/**
@@ -28,7 +28,7 @@ The gates apply whenever Truth Structure, Truth Document, Truth Sync, Truth Prev
 - `.truthmark/config.yml`
 - route files under `docs/truthmark/`
 - routed truth docs
-- implementation, config, generated templates, schemas, and contract definitions
+- implementation, config, generated templates including section comments, schemas, and contract definitions
 - tests and existing canonical docs as corroboration
 
 ## Execution Model
@@ -81,7 +81,7 @@ Shape repair does not cover ownership splits. Broad or mixed-owner docs require 
 
 ### Template And Decision Guidance
 
-Generated workflows point to the routed truth kind's matching template under `docs/templates/`, rendered as `docs/templates/<kind>-doc.md`. Agents inspect the routed truth kind, align existing docs to the template while preserving accurate authored content, and fall back to the built-in minimal truth-doc structure only when the matching template is missing.
+Generated workflows point to the routed truth kind's matching template under `docs/templates/`, rendered as `docs/templates/<kind>-doc.md`. Agents inspect the routed truth kind, read the matching template file, and treat the HTML comments under each template section as normative authoring guidance for that section. Shape alignment is not only heading alignment: agents write or repair section content so it satisfies the comment guidance while preserving accurate authored content. Workflows fall back to the built-in minimal truth-doc structure only when the matching template is missing.
 
 Decision truth lives in the canonical doc it governs. Active decisions are dated inline when added or changed; separate active-decision ADR or planning logs are rejected.
 
@@ -100,12 +100,15 @@ The gates output workflow decisions: proceed inside a bounded owner, repair shap
 - Decision (2026-05-15): Evidence validation is changed-claim-only and requires primary checkout evidence.
 - Decision (2026-05-15): Generated workflow surfaces refer to routed truth-doc templates instead of embedding full template text.
 - Decision (2026-05-15): Truth-doc split, restructure, and shape repair must preserve, move, explicitly narrow/remove with evidence, or block every pre-existing Product Decision and Rationale entry.
+- Decision (2026-05-31): Template section comments are normative authoring guidance for truth-doc content. Agents must satisfy those comments, not merely copy the matching `##` headings.
 
 ## Rationale
 
 The product is the workflow. Agents must choose the correct owner before making local edits, otherwise evidence-backed prose can still preserve the wrong truth boundary.
 
 Keeping ownership, evidence, and shape repair separate prevents broad-doc cleanup from hiding topology drift.
+
+Treating section comments as authoring guidance keeps templates lightweight while still carrying the quality bar agents need for useful section content.
 
 ## Non-Goals
 
@@ -115,4 +118,4 @@ Keeping ownership, evidence, and shape repair separate prevents broad-doc cleanu
 
 ## Maintenance Notes
 
-Update this doc when shared gate wording, template rules, decision-truth behavior, evidence reporting, or ownership/split behavior changes.
+Update this doc when shared gate wording, template-comment guidance, template rules, decision-truth behavior, evidence reporting, or ownership/split behavior changes.

--- a/docs/truth/workflows/shared-gates.md
+++ b/docs/truth/workflows/shared-gates.md
@@ -35,7 +35,9 @@ The gates apply whenever Truth Structure, Truth Document, Truth Sync, Truth Prev
 
 Ownership comes first. Evidence review and shape repair are valid only after the target or source truth doc is confirmed as a bounded owner for the behavior.
 
-## Ownership Gate
+## Steps
+
+### Ownership Gate
 
 Before editing or relying on a truth doc, the workflow verifies that each target or source truth doc is a bounded owner for the behavior. If a doc mixes independent owners, spans unrelated behaviors, acts as an index, or needs cross-owner edits, the workflow must not patch or repair it in place.
 
@@ -43,7 +45,7 @@ Truth Sync and Truth Document switch to Truth Structure when ownership repair is
 
 Reports name the ownership result: `Ownership reviewed`, `Structure required`, `Truth docs split`, `Truth docs restructured`, or `Blocked reason`.
 
-## Product Decisions/Rationale Preservation Gate
+### Product Decisions/Rationale Preservation Gate
 
 Before any truth-doc split, restructure, or shape repair, the workflow inventories existing `Product Decisions` and `Rationale` sections in every source or touched truth doc.
 
@@ -53,7 +55,7 @@ A decision or rationale may be removed or narrowed only when checkout evidence s
 
 After the edit, every touched truth doc must still have `Product Decisions` and `Rationale` sections, and every pre-existing entry must be preserved, moved, narrowed, removed with evidence, or blocked.
 
-## Evidence Gate
+### Evidence Gate
 
 Truth Structure, Truth Document, and Truth Sync validate new or changed behavior-bearing claims only. Agents map the changed or documented behavior to bounded route owners and primary canonical docs, support changed claims with primary checkout evidence, use tests and existing docs only as corroboration when implementation conflicts, and remove, narrow, or block unsupported claims.
 
@@ -63,7 +65,7 @@ Truth Check uses an audit-shaped gate: findings and suggested fixes need evidenc
 
 Truth Sync and Truth Document completed reports have deterministic structured parsers for Markdown reports with `Evidence checked` entries shaped as `- Claim: ...`, indented `Evidence: ...`, and indented `Result: supported | narrowed | removed | blocked`.
 
-## Repository Intelligence Boundary
+### Repository Intelligence Boundary
 
 RepoIndex, RouteMap, ImpactSet, and ContextPack are derived acceleration artifacts. They may guide routing, context selection, evidence review, and verification planning, but they do not own truth, route authority, or write permissions.
 
@@ -71,17 +73,25 @@ When the Truthmark CLI is unavailable, workflows must inspect `.truthmark/config
 
 If a repository-intelligence artifact conflicts with the current checkout, the checkout wins. Agents rerun the CLI when available or ignore the stale artifact when it cannot be regenerated. ContextPack-only content is not evidence; generated truth docs must cite checkout files, route files, truth docs, tests, schemas, or explicit evidence blocks.
 
-## Shape Repair Gate
+### Shape Repair Gate
 
 Shape repair is in-place cleanup inside an already-bounded truth owner. It covers missing template sections, stale evidence conflicts, cross-section updates within one owner, or wrong frontmatter/source/headings.
 
 Shape repair does not cover ownership splits. Broad or mixed-owner docs require Truth Structure before claim updates.
 
-## Template And Decision Guidance
+### Template And Decision Guidance
 
 Generated workflows point to the routed truth kind's matching template under `docs/templates/`, rendered as `docs/templates/<kind>-doc.md`. Agents inspect the routed truth kind, align existing docs to the template while preserving accurate authored content, and fall back to the built-in minimal truth-doc structure only when the matching template is missing.
 
 Decision truth lives in the canonical doc it governs. Active decisions are dated inline when added or changed; separate active-decision ADR or planning logs are rejected.
+
+## State, Retry, And Failure Behavior
+
+If ownership is unclear, broad, mixed, stale, catch-all, or unrouteable, workflows must stop local claim edits and run or recommend Truth Structure. If evidence is insufficient, workflows narrow or remove unsupported claims or block with a report. If CLI-derived context conflicts with checkout evidence, the checkout wins and derived artifacts must be rerun or ignored.
+
+## Outputs
+
+The gates output workflow decisions: proceed inside a bounded owner, repair shape in place, hand off to Truth Structure, block for ambiguity, or report unsupported/stale claims. They do not output canonical content by themselves.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/truth-check.md
+++ b/docs/truth/workflows/truth-check.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-16
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/truth-check.ts
   - ../../../src/checks/**
@@ -14,7 +14,7 @@ source_of_truth:
 
 ## Purpose
 
-Truth Check audits repository truth health.
+Truth Check protects repository-truth health by auditing configured routes, canonical docs, implementation evidence, and optional CLI diagnostics without becoming a code verifier or silent repair workflow.
 
 ## Scope
 
@@ -22,7 +22,8 @@ Truth Check owns agent-led truth-health review. It reports issues and suggested 
 
 ## Triggers
 
-- explicit user invocation through the installed host surface
+- explicit user invocation through an installed host surface such as `/truthmark-check`, `$truthmark-check`, `/skill truthmark-check`, or `/truthmark:check`
+- a user request to audit an area, document path, route owner, stale claim, topology concern, or overall truth-health state
 
 ## Inputs
 
@@ -76,8 +77,9 @@ Audits must identify ownership drift, not only stale claims. Reporting mixed-own
 
 ## Non-Goals
 
-- no silent rewrite of unrelated files
-- no replacement for normal code verification
+- no silent rewrite of unrelated files, functional code, route files, or truth docs
+- no replacement for normal lint, tests, typecheck, build checks, or code review
+- no topology repair in place when findings require Truth Structure ownership
 
 ## Maintenance Notes
 

--- a/docs/truth/workflows/truth-check.md
+++ b/docs/truth/workflows/truth-check.md
@@ -36,7 +36,15 @@ Truth Check owns agent-led truth-health review. It reports issues and suggested 
 
 Truth Check inspects the checkout directly and may optionally run `truthmark check` when local tooling is available. Installed workflows must not depend on the binary being present. In Codex, Claude Code, GitHub Copilot, Gemini CLI, or OpenCode, Truth Check may automatically use generated read-only verifier subagents when the host supports subagent dispatch and the parent agent chooses bounded fan-out.
 
-## Current Behavior
+## Steps
+
+1. Inspect configured Truthmark config, route files, canonical docs, implementation, and tests.
+2. Optionally run local `truthmark check` when available.
+3. Identify stale claims, weak route ownership, missing decision/rationale coverage, topology issues, and unsupported truth-doc content.
+4. Support each finding and suggested fix with checkout evidence.
+5. Report issues without silently rewriting unrelated files.
+
+Current behavior notes:
 
 Truth Check verifies that current docs describe current code rather than historical plans, route files map code surfaces to canonical truth docs, canonical behavior docs keep active Product Decisions and Rationale sections, and broad, catch-all, index-like, or mixed-owner truth docs are reported as topology issues requiring Truth Structure.
 
@@ -47,6 +55,14 @@ If follow-up docs edits are needed for mixed-owner docs, Truth Check runs or rec
 When subagent mode is available, the parent agent may dispatch read-only route, claim, and doc-shape verifier workers across bounded shards. Codex exposes `truth_route_auditor`, `truth_claim_verifier`, and `truth_doc_reviewer`; Claude Code exposes `truth-route-auditor`, `truth-claim-verifier`, and `truth-doc-reviewer` project subagents; GitHub Copilot, Gemini CLI, and OpenCode expose `@truth-route-auditor`, `@truth-claim-verifier`, and `@truth-doc-reviewer`. Workers return structured findings only and must not edit files. They inspect only the parent-assigned shard plus required checkout evidence files and do not preload repo-wide instruction or policy docs unless the parent assigns those files as evidence. The parent agent deduplicates findings, spot-checks evidence, optionally runs validation, and owns repo-policy interpretation and the final Truth Check report.
 
 Completed reports include `Files reviewed`, `Issues found`, `Fixes suggested`, `Evidence checked`, and `Validation`.
+
+## State, Retry, And Failure Behavior
+
+Truth Check is read-only by default. If local CLI tooling is unavailable, it proceeds by direct checkout inspection and reports that optional CLI diagnostics were not generated. Mixed-owner docs are reported as topology issues instead of silently repaired.
+
+## Outputs
+
+Truth Check outputs an audit report with findings, evidence, severity or priority, and suggested fixes. It does not replace lint, tests, typecheck, code review, or Truth Sync.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/truth-document.md
+++ b/docs/truth/workflows/truth-document.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-18
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/truth-document.ts
   - ../../../src/agents/write-lease.ts
@@ -45,7 +45,7 @@ Truth Document is implementation-first and never writes functional code. It docu
 1. Confirm the user is asking to document existing implemented behavior rather than change functional code.
 2. Inspect implementation, tests, config, route files, and existing canonical docs.
 3. Apply the ownership gate and run Truth Structure first when routing or truth ownership is unsafe and repair is in scope.
-4. Create or update only routed canonical truth docs and route files needed for the documented behavior.
+4. Create or update only routed canonical truth docs and route files needed for the documented behavior, using the routed truth kind's template and its section-comment guidance for touched truth-doc content.
 5. Preserve active Product Decisions and Rationale during bounded shape repair or Structure handoff.
 6. Report evidence, written docs, routing changes, and blocked ambiguities.
 
@@ -56,6 +56,8 @@ Truth Document applies the ownership gate before writing. If routing is missing,
 If the candidate truth doc is broad, mixed-owner, index-like, or the documented behavior spans independent owners, Truth Document does not repair it in place. It switches to Truth Structure or blocks.
 
 When ownership is bounded, Truth Document creates or updates leaf truth docs, keeps behavior truth docs behavior-oriented, keeps API endpoint details in the nearest contract truth doc when that doc owns the contract, and preserves unrelated authored content.
+
+When creating or updating a truth doc, Truth Document uses the routed `truth_kind` to select `docs/templates/<kind>-doc.md`. The HTML comments under each selected template section are normative authoring guidance for that section; Document must write content that satisfies the comment guidance while preserving supported existing claims.
 
 When Truth Document restructures a bounded truth doc or runs Structure first, it inventories Product Decisions and Rationale before editing. Existing entries must be preserved in or moved to their bounded owner docs, narrowed or removed only with checkout evidence, or blocked for manual review when ownership is unclear.
 
@@ -82,6 +84,7 @@ Truth Document outputs canonical truth-doc and route-file changes plus a complet
 - Decision (2026-05-15): Truth Document must switch to Truth Structure rather than patching mixed-owner truth docs.
 - Decision (2026-05-15): Truth Document must not lose Product Decisions or Rationale during bounded shape repair or Structure handoff.
 - Decision (2026-05-16): Codex, Claude Code, GitHub Copilot, Gemini CLI, and OpenCode subagents may gather bounded read-only evidence for Document without preloading repo-wide policy by default. Document may also dispatch `truth-doc-writer` only with an explicit write lease, while parent agents retain policy, acceptance, and diff-validation ownership.
+- Decision (2026-05-31): Truth Document treats template section comments as the section-level content standard for authored or repaired truth-doc prose.
 
 ## Rationale
 
@@ -89,10 +92,10 @@ Documentation-only work can still damage repository truth if it appends implemen
 
 ## Non-Goals
 
-- no functional-code edits
-- no planned behavior documentation
-- no in-place ownership repair for mixed-owner docs
+- no functional-code edits or generated code changes
+- no planned behavior documentation, speculative endpoints, or roadmap prose
+- no in-place ownership repair for mixed-owner docs; hand off to Truth Structure instead
 
 ## Maintenance Notes
 
-Update this doc when Truth Document triggers, write boundaries, ownership handoff behavior, or report shape changes.
+Update this doc when Truth Document triggers, write boundaries, template-authoring guidance, ownership handoff behavior, or report shape changes.

--- a/docs/truth/workflows/truth-document.md
+++ b/docs/truth/workflows/truth-document.md
@@ -40,7 +40,16 @@ Truth Document owns manual missing-truth generation for implemented behavior. It
 
 Truth Document is implementation-first and never writes functional code. It documents current implemented behavior only and does not invent future behavior or planned endpoints. In Codex, Claude Code, GitHub Copilot, Gemini CLI, or OpenCode, Truth Document may automatically use generated read-only verifier subagents and explicit-lease `truth-doc-writer` subagents when the host supports subagent dispatch and the parent agent chooses bounded fan-out.
 
-## Current Behavior
+## Steps
+
+1. Confirm the user is asking to document existing implemented behavior rather than change functional code.
+2. Inspect implementation, tests, config, route files, and existing canonical docs.
+3. Apply the ownership gate and run Truth Structure first when routing or truth ownership is unsafe and repair is in scope.
+4. Create or update only routed canonical truth docs and route files needed for the documented behavior.
+5. Preserve active Product Decisions and Rationale during bounded shape repair or Structure handoff.
+6. Report evidence, written docs, routing changes, and blocked ambiguities.
+
+Current behavior notes:
 
 Truth Document applies the ownership gate before writing. If routing is missing, stale, broad, overloaded, catch-all, or cannot map behavior to a bounded truth owner, it runs Truth Structure first when repair is safe and in scope. If repair is unsafe, ambiguous, or outside the task boundary, it blocks and recommends Truth Structure.
 
@@ -58,6 +67,14 @@ When subagent mode is available, the parent agent may dispatch read-only route a
 
 Completed reports include `Implementation reviewed`, `Ownership reviewed`, `Structure required` when applicable, `Truth docs created`, `Truth docs updated`, `Truth docs restructured`, `Routing updated`, `Evidence checked`, `Helper scripts`, and `Notes`. Required completed-report sections must contain at least one bullet entry, `Evidence checked` must use structured `Claim`, indented `Evidence`, and `Result` entries, and blocked reports must include `Reason` for helper validation to accept them.
 When write workers are used, each worker report must include `status`, `worker`, `workflow`, `shard`, `filesChanged`, `claimsChecked`, `evidenceChecked`, `offLeaseChanges`, `blockers`, and `notes`. The parent accepts a completed worker report only after validating the parsed report against the lease identity, required report fields, actual worker diff, `allowedWrites`, `forbiddenWrites`, reported `filesChanged`, reported `offLeaseChanges`, and reported `blockers`. Blocked worker reports remain blocked outcomes and must include blockers; off-lease or forbidden actual diffs are rejected rather than trusted from self-report.
+
+## State, Retry, And Failure Behavior
+
+If routing is missing, stale, broad, overloaded, catch-all, or cannot map behavior to a bounded owner, Truth Document either runs Truth Structure when safe and in scope or blocks and recommends it. If helper/subagent support is unavailable, the parent agent performs the same checks manually.
+
+## Outputs
+
+Truth Document outputs canonical truth-doc and route-file changes plus a completion report. It does not output functional-code changes or planned-behavior docs.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/truth-preview.md
+++ b/docs/truth/workflows/truth-preview.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-16
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/truth-preview.ts
   - ../../../src/agents/workflow-manifest.ts
@@ -79,10 +79,9 @@ Preview improves agent performance only when it prevents unnecessary workflow lo
 
 ## Non-Goals
 
-- no automatic invocation
-- no validation gate
-- no Truth Check replacement
-- no file mutation
+- no automatic invocation, mutation, or approval bypass before the user chooses a follow-up workflow
+- no validation gate, final correctness claim, or replacement for Truth Check
+- no write leases, write-worker dispatch, route updates, truth-doc edits, or functional-code mutation
 
 ## Maintenance Notes
 

--- a/docs/truth/workflows/truth-preview.md
+++ b/docs/truth/workflows/truth-preview.md
@@ -12,6 +12,10 @@ source_of_truth:
 
 # Truth Preview
 
+## Purpose
+
+Truth Preview protects a read-only, explicit planning surface for previewing likely Truthmark routing, workflow choice, write classes, target files, and handoff before edits.
+
 ## Scope
 
 Truth Preview previews likely Truthmark routing before edits.
@@ -22,6 +26,14 @@ It is an explicit read-only planning surface. It is intended, not authorized, an
 
 - explicit user invocation through the installed host surface
 - questions about likely workflow routing, route ownership, target files, write classes, or subagent use before edits
+
+## Inputs
+
+- `.truthmark/config.yml`
+- root and child route files
+- relevant canonical docs
+- relevant implementation files
+- the user's requested focus or proposed change
 
 ## Execution Model
 
@@ -39,6 +51,21 @@ Truth Preview may suggest the read-only route auditor when bounded verifier inpu
 Truth Preview must not edit files, create truth docs, update routing, run Truth Sync automatically, replace Truth Check, claim final correctness, issue write leases, or mutate code.
 
 Completed reports include `Requested outcome`, `Likely workflow`, `Why this workflow`, `Likely route owner`, `Expected write classes`, `Expected target files`, `Suggested subagent use`, `Blocking ambiguity`, and `Handoff`.
+
+## Steps
+
+1. Read only the config, routes, canonical docs, and implementation needed to preview ownership.
+2. Identify the likely Truthmark workflow, route owner, write classes, target files, and useful subagent mode.
+3. Report ambiguity or blocking ownership risk instead of mutating files.
+4. Hand off to the selected workflow only after user approval or explicit follow-up.
+
+## State, Retry, And Failure Behavior
+
+Truth Preview is read-only and has no retry state beyond re-running the preview with more specific context. If ownership is ambiguous, the output states the ambiguity and recommends the next workflow instead of authorizing edits.
+
+## Outputs
+
+Truth Preview outputs a planning report: likely workflow, selection rationale, likely route owner, expected write classes, expected target files, suggested subagent use, blocking ambiguity, and handoff. It does not create, update, or validate repository files.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/truth-realize.md
+++ b/docs/truth/workflows/truth-realize.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-16
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/prompts.ts
   - ../../../src/templates/workflow-surfaces.ts
@@ -13,7 +13,7 @@ source_of_truth:
 
 ## Purpose
 
-Truth Realize implements functional code from existing canonical truth docs.
+Truth Realize protects doc-first implementation by turning bounded, current canonical truth claims into functional code while keeping truth docs and routing read-only for the run.
 
 ## Scope
 
@@ -21,7 +21,8 @@ Truth Realize is doc-first and manual. Truth docs lead, code follows, and the ag
 
 ## Triggers
 
-- explicit user invocation through the installed host surface
+- explicit user invocation through an installed host surface such as `/truthmark-realize`, `$truthmark-realize`, `/skill truthmark-realize`, or `/truthmark:realize`
+- a user request that specifically asks to realize existing truth docs into code, not a generic code edit or documentation task
 
 ## Inputs
 
@@ -71,9 +72,9 @@ Doc-first implementation is only reliable when the source truth has a bounded ow
 
 ## Non-Goals
 
-- no truth-doc edits
-- no routing edits
-- no implementation from ambiguous source truth
+- no truth-doc edits, template rewrites, or truth-routing changes
+- no automatic invocation as a finish gate for ordinary code tasks
+- no implementation from broad, mixed-owner, stale, unrouteable, or implementation-conflicting source truth
 
 ## Maintenance Notes
 

--- a/docs/truth/workflows/truth-realize.md
+++ b/docs/truth/workflows/truth-realize.md
@@ -34,7 +34,15 @@ Truth Realize is doc-first and manual. Truth docs lead, code follows, and the ag
 
 Truth Realize must read source truth docs, routing, and relevant code before writing functional code. It must not edit truth docs or truth routing.
 
-## Current Behavior
+## Steps
+
+1. Read source truth docs, routing metadata, relevant implementation code, tests, and config.
+2. Verify the source truth docs are bounded, current, routeable, and not mixed-owner or index-like.
+3. Implement only the bounded current truth claims from the source docs.
+4. Run relevant tests or report why they could not run.
+5. Report changed functional-code files and verification.
+
+Current behavior notes:
 
 Truth Realize applies the ownership gate to source truth docs before writing code. If a source truth doc is broad, mixed-owner, index-like, unrouteable, stale, or conflicts with implementation evidence, Truth Realize blocks before writing code and recommends Truth Structure or Truth Document.
 
@@ -43,6 +51,14 @@ When source truth is bounded and current, Truth Realize implements only the boun
 Completion reports include `Truth docs used`, `Code updated`, and `Verification`.
 
 ContextPack may be used to collect bounded implementation context when available. It does not replace checkout inspection, does not grant write permission outside the workflow boundary, and cannot override source truth docs or current code. If ContextPack is unavailable, Truth Realize proceeds manually and reports that repository-intelligence artifacts were not generated.
+
+## State, Retry, And Failure Behavior
+
+Truth Realize blocks before writing code when source truth is broad, mixed-owner, stale, unrouteable, or conflicts with implementation evidence. It remains explicit and manual-only.
+
+## Outputs
+
+Truth Realize outputs functional-code changes and a verification report. It must not output truth-doc edits or route-file edits.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/truth-structure.md
+++ b/docs/truth/workflows/truth-structure.md
@@ -40,7 +40,16 @@ Truth Structure also owns new area setup when a user asks to onboard a new code 
 Truth Structure inspects the checkout directly and defines areas by product or behavior ownership, not mechanical directory mirroring.
 For new area setup, Truth Structure inspects the named code area, infers bounded product or behavior ownership, chooses the owning route when ownership is clear, and otherwise proposes the route and blocks for review. It creates or updates the child route entry or file, creates starter truth docs only where current truth is missing, and reports the initial truth boundary.
 
-## Current Behavior
+## Steps
+
+1. Inspect repository layout, config, root and child route files, current canonical docs, representative implementation boundaries, and tests.
+2. Identify topology pressure such as broad code mappings, overloaded child route files, mixed-owner docs, catch-all routing, or unrouteable changed code.
+3. Design bounded behavior or product ownership areas rather than mechanical directory mirrors.
+4. Update route files and create or move starter truth docs where ownership is clear and current-state evidence supports them.
+5. Preserve or explicitly account for Product Decisions and Rationale when splitting or restructuring truth docs.
+6. Verify route and truth health with Truthmark checks when available.
+
+Current behavior notes:
 
 When topology pressure exists, Truth Structure repairs structure before creating or extending truth docs.
 
@@ -56,6 +65,14 @@ Starter truth docs use closed YAML frontmatter with `status`, `doc_type`, `last_
 New area setup must not edit functional code, perform full behavior documentation unless evidence is inspected and the task explicitly asks for it, patch broad or mixed-owner docs in place, create generic catch-all docs, or treat README files as Sync targets.
 
 Completed reports include `Topology reviewed`, `Areas reviewed`, `Routing updated`, `Initial truth boundary`, `Truth docs created`, `Truth docs split`, `Truth docs restructured`, `Evidence checked`, `Topology decisions`, and `Notes`.
+
+## State, Retry, And Failure Behavior
+
+Truth Structure may block instead of writing when ownership is ambiguous, route repair is outside task scope, or evidence is insufficient. It performs topology repair before claim expansion.
+
+## Outputs
+
+Truth Structure outputs route topology changes, bounded starter truth docs when supported, and a report explaining ownership decisions, preserved decisions/rationale, verification, and any blocked ambiguities.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/truth-structure.md
+++ b/docs/truth/workflows/truth-structure.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-16
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/truth-structure.ts
   - ../../../src/agents/shared.ts
@@ -14,7 +14,7 @@ source_of_truth:
 
 ## Purpose
 
-Truth Structure designs or repairs repository truth topology.
+Truth Structure protects bounded repository-truth topology so generated agent workflows can route code areas, truth docs, and ownership repair to the right current-state owner before any truth prose is expanded.
 
 ## Scope
 
@@ -45,7 +45,7 @@ For new area setup, Truth Structure inspects the named code area, infers bounded
 1. Inspect repository layout, config, root and child route files, current canonical docs, representative implementation boundaries, and tests.
 2. Identify topology pressure such as broad code mappings, overloaded child route files, mixed-owner docs, catch-all routing, or unrouteable changed code.
 3. Design bounded behavior or product ownership areas rather than mechanical directory mirrors.
-4. Update route files and create or move starter truth docs where ownership is clear and current-state evidence supports them.
+4. Update route files and create or move starter truth docs where ownership is clear and current-state evidence supports them, using the routed truth kind's template and section-comment guidance for any starter or repaired truth doc.
 5. Preserve or explicitly account for Product Decisions and Rationale when splitting or restructuring truth docs.
 6. Verify route and truth health with Truthmark checks when available.
 
@@ -61,7 +61,7 @@ In Codex, Claude Code, GitHub Copilot, Gemini CLI, and OpenCode, Truth Structure
 
 Before splitting or restructuring truth docs, Truth Structure inventories Product Decisions and Rationale in every source doc. It moves each current entry into the bounded owner doc it governs, removes or narrows entries only with checkout evidence, and blocks with manual-review files when ownership is unclear.
 
-Starter truth docs use closed YAML frontmatter with `status`, `doc_type`, `last_reviewed`, and `source_of_truth`, and include `Product Decisions` and `Rationale` sections.
+Starter truth docs use closed YAML frontmatter with `status`, `doc_type`, `last_reviewed`, and `source_of_truth`, and include `Product Decisions` and `Rationale` sections. When a routed template exists, Structure follows the HTML comments under each template section as the authoring guidance for starter or repaired section content rather than treating the template as headings only.
 New area setup must not edit functional code, perform full behavior documentation unless evidence is inspected and the task explicitly asks for it, patch broad or mixed-owner docs in place, create generic catch-all docs, or treat README files as Sync targets.
 
 Completed reports include `Topology reviewed`, `Areas reviewed`, `Routing updated`, `Initial truth boundary`, `Truth docs created`, `Truth docs split`, `Truth docs restructured`, `Evidence checked`, `Topology decisions`, and `Notes`.
@@ -81,6 +81,7 @@ Truth Structure outputs route topology changes, bounded starter truth docs when 
 - Decision (2026-05-15): Truth Structure must preserve or explicitly account for Product Decisions and Rationale when splitting or restructuring truth docs.
 - Decision (2026-05-16): Codex, Claude Code, GitHub Copilot, Gemini CLI, and OpenCode Truth Structure may use the generated read-only route auditor for bounded validation input without preloading repo-wide policy by default, while parent agents retain policy and topology write ownership.
 - Decision (2026-05-16): New area setup is a Truth Structure scenario, not a separate workflow surface. It may add routing and starter truth docs, but detailed behavior documentation remains bounded by evidence and explicit task scope.
+- Decision (2026-05-31): Starter and repaired truth docs must satisfy routed template section comments when templates are available, because topology repair should leave useful bounded content, not only valid headings.
 
 ## Rationale
 
@@ -94,4 +95,4 @@ Ownership repair needs a workflow that can change route topology and create boun
 
 ## Maintenance Notes
 
-Update this doc when topology pressure signals, split behavior, starter-doc requirements, Structure subagent behavior, or Structure report shape changes.
+Update this doc when topology pressure signals, split behavior, starter-doc template guidance, Structure subagent behavior, or Structure report shape changes.

--- a/docs/truth/workflows/truth-sync.md
+++ b/docs/truth/workflows/truth-sync.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-18
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/truth-sync.ts
   - ../../../src/agents/write-lease.ts
@@ -19,7 +19,7 @@ source_of_truth:
 
 ## Purpose
 
-Truth Sync aligns canonical truth docs with functional-code changes.
+Truth Sync protects the completion-time contract that changed functional code is reflected in bounded canonical truth docs and truth routing without letting documentation-only updates or topology repair blur workflow ownership.
 
 ## Scope
 
@@ -46,7 +46,7 @@ Truth Sync may update routed truth docs and routing when routing repair is neede
 1. Determine whether functional code changed since the last successful Sync or whether the user explicitly invoked Sync.
 2. Inspect changed code, config, route files, impacted truth docs, nearby implementation, and tests.
 3. Apply topology and ownership gates before changing truth docs.
-4. Update only routed truth docs and routing needed to keep canonical truth aligned with changed code.
+4. Update only routed truth docs and routing needed to keep canonical truth aligned with changed code, using the routed truth kind's template and its section-comment guidance for touched truth-doc content.
 5. Preserve active Product Decisions and Rationale during bounded shape repair or Structure handoff.
 6. Report changed truth files, evidence, skipped cases, verification, and any blocked topology repair.
 
@@ -59,6 +59,8 @@ If an impacted truth doc is broad, mixed-owner, index-like, or the code change s
 Truth Sync updates active decisions and rationale in the routed canonical doc when implementation changes are driven by a decision change. It dates active decisions inline when added or changed and replaces stale active decisions rather than appending separate timestamped decision notes.
 
 When Truth Sync restructures a bounded truth doc or runs Structure inline, it inventories Product Decisions and Rationale before editing. Existing entries must be preserved in or moved to their bounded owner docs, narrowed or removed only with checkout evidence, or blocked for manual review when ownership is unclear.
+
+When Truth Sync creates, updates, or repairs a truth doc, it uses the routed `truth_kind` to select `docs/templates/<kind>-doc.md`. The HTML comments under that template's section headings are part of the authoring contract: Sync must satisfy the section intent for changed content, not just preserve or copy the headings.
 
 Truth Sync updates architecture docs in the same sync when changed code alters architecture-level structure or ownership.
 
@@ -97,6 +99,7 @@ Truth Sync outputs truth-doc and route-file updates plus a completion report. It
 - Decision (2026-05-15): Truth Sync must not lose Product Decisions or Rationale during bounded shape repair or inline Structure handoff.
 - Decision (2026-05-16): Codex, Claude Code, GitHub Copilot, Gemini CLI, and OpenCode subagents may automatically gather bounded read-only route and claim evidence for Sync when host-supported without preloading repo-wide policy by default. Sync may also dispatch `truth-doc-writer` only with an explicit write lease, while parent agents retain policy, acceptance, and diff-validation ownership.
 - Decision (2026-05-16): Truth Sync write authority is bounded by file class and route ownership, not by the root route index alone. It may write canonical truth docs and truth routing files, while functional code remains outside Sync authority.
+- Decision (2026-05-31): Truth Sync follows the selected truth-doc template's section comments as content guidance for touched sections, because template compliance requires useful section content as well as matching headings.
 
 ## Rationale
 
@@ -110,4 +113,4 @@ Truth Sync is the finish-time bridge from code to truth, so it must protect rout
 
 ## Maintenance Notes
 
-Update this doc when Sync triggers, skip reasons, report shape, delegation language, or ownership handoff behavior changes.
+Update this doc when Sync triggers, skip reasons, report shape, delegation language, template-authoring guidance, or ownership handoff behavior changes.

--- a/docs/truth/workflows/truth-sync.md
+++ b/docs/truth/workflows/truth-sync.md
@@ -41,7 +41,16 @@ Truth Sync is code-first. Code leads, truth docs follow, and functional code mus
 
 Truth Sync may update routed truth docs and routing when routing repair is needed. It may create missing canonical truth docs when routeable implementation would otherwise remain undocumented. In Codex, Claude Code, GitHub Copilot, Gemini CLI, or OpenCode, Truth Sync may automatically use generated read-only verifier subagents and explicit-lease `truth-doc-writer` subagents when the host supports subagent dispatch and the parent agent chooses bounded fan-out.
 
-## Current Behavior
+## Steps
+
+1. Determine whether functional code changed since the last successful Sync or whether the user explicitly invoked Sync.
+2. Inspect changed code, config, route files, impacted truth docs, nearby implementation, and tests.
+3. Apply topology and ownership gates before changing truth docs.
+4. Update only routed truth docs and routing needed to keep canonical truth aligned with changed code.
+5. Preserve active Product Decisions and Rationale during bounded shape repair or Structure handoff.
+6. Report changed truth files, evidence, skipped cases, verification, and any blocked topology repair.
+
+Current behavior notes:
 
 Before updating truth docs, Truth Sync applies the topology and ownership gates. If routing is missing, stale, broad, overloaded, catch-all, or cannot map changed code to a bounded truth owner, it must not create another generic truth doc. It runs Truth Structure first when repair is safe and in scope, or blocks and recommends Truth Structure when topology repair is unsafe, ambiguous, or outside the task boundary.
 
@@ -71,6 +80,14 @@ Current skip reasons are:
 Truth Sync's generated frontmatter description and Codex metadata carry those skip cases because skill metadata is the host-visible routing boundary before the full workflow body is loaded.
 
 Truth Sync delegation is host-owned. Generated workflow surfaces may describe when delegation is allowed, but must not create unrestricted writable helpers or a project-local subagent preference file. Codex, Claude Code, GitHub Copilot, Gemini CLI, and OpenCode generated surfaces may name project-scoped read-only verifier agents for workflow-owned automatic verification and `truth-doc-writer` for leased truth-doc shards. Read-only verifier agents inspect only the parent-assigned shard plus required checkout evidence files and do not preload repo-wide instruction or policy docs unless the parent assigns those files as evidence. The parent workflow creates each lease, requires allowedWrites and forbiddenWrites, validates the actual checkout diff against the lease, and owns repo-policy interpretation and final acceptance.
+
+## State, Retry, And Failure Behavior
+
+Truth Sync is skipped for docs-only, formatting-only, behavior-preserving rename, missing-config, or no-code changes. It blocks or hands off to Truth Structure when routing is missing, stale, broad, overloaded, catch-all, or unrouteable. It must not rewrite functional code during sync.
+
+## Outputs
+
+Truth Sync outputs truth-doc and route-file updates plus a completion report. It does not output functional-code rewrites or generic docs behind weak routing.
 
 ## Product Decisions
 

--- a/docs/truth/workflows/truthmark-portal.md
+++ b/docs/truth/workflows/truthmark-portal.md
@@ -2,7 +2,7 @@
 status: active
 doc_type: behavior
 truth_kind: workflow
-last_reviewed: 2026-05-25
+last_reviewed: 2026-05-31
 source_of_truth:
   - ../../../src/agents/truthmark-portal.ts
   - ../../../src/agents/workflow-manifest.ts
@@ -29,8 +29,11 @@ Portal runs only from an explicit user request to generate, refresh, or update t
 
 ## Inputs
 
-- configured repository files
-- relevant checkout evidence
+- `.truthmark/config.yml`, especially the namespaced `truthmark-portal` block when present
+- configured route docs and Markdown truth sources selected for presentation
+- repository instruction, architecture, and standards Markdown when they are part of the requested Portal source set
+- configured Portal template when the selected template is a repository-relative file
+- optional local `truthmark check` or `truthmark index` output used only as supporting evidence, never as required infrastructure
 
 ## Execution Model
 

--- a/docs/truth/workflows/truthmark-portal.md
+++ b/docs/truth/workflows/truthmark-portal.md
@@ -27,11 +27,24 @@ This document owns the installed Portal workflow boundary, config toggle, genera
 
 Portal runs only from an explicit user request to generate, refresh, or update the committed static HTML presentation site. It is not triggered by Truth Sync, `truthmark check`, `truthmark init`, repository indexing, or normal completion workflows.
 
+## Inputs
+
+- configured repository files
+- relevant checkout evidence
+
 ## Execution Model
 
 Portal is an agent-executed workflow that reads Markdown truth sources from the checkout and writes presentation output under the configured Portal output directory. The generated HTML, assets, and metadata are non-canonical; Markdown truth documents remain authoritative.
 
-## Current Behavior
+## Steps
+
+1. Confirm the user explicitly requested Portal generation or refresh.
+2. Read the namespaced `truthmark-portal` config block and normalize defaults.
+3. Inspect Markdown truth sources from the checkout.
+4. Write presentation output only under the configured Portal output directory.
+5. Keep generated HTML, assets, and metadata non-canonical and report what was refreshed.
+
+Current behavior notes:
 
 `.truthmark/config.yml` may contain a namespaced `truthmark-portal` block. The raw YAML key is exactly `truthmark-portal`; normalized config exposes `truthmarkPortal`.
 
@@ -58,6 +71,14 @@ The workflow reads Markdown directly from the checkout and does not require the 
 Portal writes generated non-canonical static files only under the configured output directory unless the user explicitly changes scope. The selected output directory may be replaced entirely during generation.
 
 Generated output should be a committed multi-page static HTML site with local CSS, JavaScript, assets, and search metadata. Generated pages must include source provenance and a visible statement that Markdown remains canonical and generated HTML is presentation only. Manifest and search metadata stay under `<output>/assets`. No remote scripts, analytics, fonts, CSS, or CDN dependencies are used by default. Pictures and screenshots require an explicit user or template request.
+
+## State, Retry, And Failure Behavior
+
+Portal remains disabled when the config block is omitted or `enabled` is omitted/false. Portal is manual-only and is not triggered by Truth Sync, `truthmark check`, `truthmark init`, repository indexing, or normal completion workflows. Generated output is replaceable presentation state, not repository truth.
+
+## Outputs
+
+Portal outputs committed static HTML presentation files, supporting assets, optional metadata under the configured output directory, and a completion report. Markdown truth docs remain authoritative.
 
 ## Product Decisions
 

--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -28,7 +28,8 @@ export const REPOSITORY_INTELLIGENCE_INSTRUCTIONS = [
 export const FEATURE_DOC_TEMPLATE_INSTRUCTIONS = [
   "When creating or updating a truth doc, inspect the routed truth kind and use the matching `docs/templates/<kind>-doc.md` template.",
   "Supported kinds: behavior, contract, architecture, workflow, operations, and test-behavior.",
-  "Align existing docs to that template while preserving accurate authored content.",
+  "Treat the HTML comments under each template section as normative authoring guidance for that section.",
+  "Align existing docs to that template and write or repair section content so it satisfies the comment guidance while preserving accurate authored content.",
   "If the template is missing, use Scope, Product Decisions, Rationale, and the kind-specific current-truth section.",
   "Teams may edit the template files under docs/templates/ to define their local truth-doc standards.",
 ].join("\n");

--- a/tests/agents/truth-document.test.ts
+++ b/tests/agents/truth-document.test.ts
@@ -47,6 +47,8 @@ describe("renderTruthDocumentSkillBody", () => {
     expect(skill).toContain("must not write functional code");
     expect(skill).toContain("docs/templates/<kind>-doc.md");
     expect(skill).toContain("When creating or updating a truth doc");
+    expect(skill).toContain("HTML comments under each template section");
+    expect(skill).toContain("normative authoring guidance");
     expect(skill).toContain("Truth-doc ownership gate");
     expect(skill).toContain(
       "if the target doc is broad, mixed-owner, index-like, or the documented behavior spans independent owners",

--- a/tests/agents/truth-structure.test.ts
+++ b/tests/agents/truth-structure.test.ts
@@ -48,6 +48,8 @@ describe("renderTruthStructureSkillBody", () => {
     expect(skill).toContain("docs/templates/<kind>-doc.md");
     expect(skill).toContain("inspect the routed truth kind");
     expect(skill).toContain("Align existing docs to that template");
+    expect(skill).toContain("HTML comments under each template section");
+    expect(skill).toContain("normative authoring guidance");
     expect(skill).toContain("Truth-doc ownership gate");
     expect(skill).toContain(
       "if a truth doc mixes independent owners, route ownership is broad, or a split is required for bounded ownership",

--- a/tests/agents/truth-sync.test.ts
+++ b/tests/agents/truth-sync.test.ts
@@ -129,6 +129,8 @@ describe("renderTruthSyncSkillBody", () => {
     expect(skillBody).toContain("docs/templates/<kind>-doc.md");
     expect(skillBody).toContain("inspect the routed truth kind");
     expect(skillBody).toContain("Align existing docs to that template");
+    expect(skillBody).toContain("HTML comments under each template section");
+    expect(skillBody).toContain("normative authoring guidance");
     expect(skillBody).toContain("Truth-doc ownership gate");
     expect(skillBody).toContain(
       "if an impacted doc is broad, mixed-owner, index-like, or the update spans independent behavior owners",


### PR DESCRIPTION
## Summary
- Align routed truth docs with current truth-kind template section shapes
- Preserve existing content while moving older headings into template sections
- Update release automation truth to setup-node@v6 and current workflow permissions

## Verification
- Template shape audit: 19 routed truth docs, 0 issues
- npx tsx src/cli/main.ts check --json
- npx tsx src/cli/main.ts index --json
- git diff --check
- npm run check