### PR TITLE
docs: cite docs/ai/repo-rules.md in local instruction files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-Follow repository instruction files that are present in this checkout; do not assume optional policy docs exist.
+Repository rule source of truth: [docs/ai/repo-rules.md](docs/ai/repo-rules.md). Follow repository instruction files that are present in this checkout; do not assume optional policy docs exist.
 
 Use explicitly configured repository policy docs only when they exist in this checkout.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-Follow repository instruction files that are present in this checkout; do not assume optional policy docs exist.
+Repository rule source of truth: [docs/ai/repo-rules.md](docs/ai/repo-rules.md). Follow repository instruction files that are present in this checkout; do not assume optional policy docs exist.
 
 Use explicitly configured repository policy docs only when they exist in this checkout.
 


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` and `CLAUDE.md` to explicitly cite `docs/ai/repo-rules.md` as the repository rule source of truth.
- Keep changes localized to the two repository instruction files.

## Test Plan
- `npx tsx src/cli/main.ts check --json`

