### PR TITLE
fix: publish npm from release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
 name: Publish
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'release/**'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/changes/2026-06-22-npm-provenance-publish-trigger.md
+++ b/changes/2026-06-22-npm-provenance-publish-trigger.md
@@ -1,0 +1,17 @@
+# Fix npm provenance publish trigger
+
+Version action: patch
+
+## PR Summary
+
+- Switch npm publishing from GitHub `release` events to `release/**` tag push events, with manual dispatch retained as an operator fallback.
+- Document that tag-triggered publishing keeps GitHub Actions OIDC provenance tied to a concrete source ref.
+
+## Release Note
+
+- Fix npm publishing provenance failures caused by release-event OIDC certificates missing `SourceRepositoryRef`.
+
+## Verification
+
+- `npm run release:check`
+- `node dist/main.js check --json`

--- a/docs/truthmark/engineering/operations/release-automation.md
+++ b/docs/truthmark/engineering/operations/release-automation.md
@@ -18,6 +18,8 @@ It covers GitHub workflow triggers, verification steps, and generated GitHub Act
 
 Release and CI behavior is implemented through checked-in GitHub workflow files and the GitHub Action template renderer.
 
+The npm publish workflow runs from `release/**` tag push events, with manual `workflow_dispatch` as an operator fallback. Tag-triggered publishing keeps the GitHub Actions OIDC signing certificate tied to a concrete `refs/tags/...` source ref for npm provenance verification.
+
 ## Operational Surface
 
 - GitHub Actions workflows under `.github/workflows/**`


### PR DESCRIPTION
## Summary
- Switch npm publishing from GitHub release events to `release/**` tag push events.
- Keep `workflow_dispatch` as an operator fallback.
- Document why tag-triggered publishing preserves the concrete source ref needed for npm provenance verification.

## Verification
- `npm run release:check`
- `node dist/main.js check --json` — Truthmark check completed with no diagnostics.
- `npx tsx src/cli/main.ts check --json`
- `npx tsx src/cli/main.ts index --json`

## Notes
- No new local changes were present when asked to commit; this publishes existing commit `47e8f79`.
